### PR TITLE
Reduce mod datatable

### DIFF
--- a/R/app_server.R
+++ b/R/app_server.R
@@ -164,7 +164,7 @@ app_server <- function( input, output, session ) {
   
   # prepare data to be displayed by mod_datatable
 
-  mod_datatable_dashboard_server("datatable_dashboard_1", dataset_dash_data)
+  mod_tabbed_dashboard_server("tabbed_dashboard_1", dataset_dash_data)
   
   
 }

--- a/R/app_server.R
+++ b/R/app_server.R
@@ -164,7 +164,7 @@ app_server <- function( input, output, session ) {
   
   # prepare data to be displayed by mod_datatable
 
-  mod_datatable_server("datatable_1", dataset_dash_data)
+  mod_datatable_dashboard_server("datatable_dashboard_1", dataset_dash_data)
   
   
 }

--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -54,7 +54,7 @@ app_ui <- function(request) {
           # dataset view dashboard tab
           shinydashboard::tabItem(tabName = "dataset-dashboard",
                                   fluidPage(
-                                    mod_datatable_ui("datatable_1")
+                                    mod_datatable_dashboard_ui("datatable_dashboard_1")
                                     )
                                   ),
           

--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -54,8 +54,7 @@ app_ui <- function(request) {
           # dataset view dashboard tab
           shinydashboard::tabItem(tabName = "dataset-dashboard",
                                   fluidPage(
-                                    mod_datatable_dashboard_ui("datatable_dashboard_1")
-                                    )
+                                    mod_tabbed_dashboard_ui("tabbed_dashboard_1"))
                                   ),
           
           # administrate tab

--- a/R/mod_datatable.R
+++ b/R/mod_datatable.R
@@ -12,38 +12,8 @@ mod_datatable_ui <- function(id){
   ns <- NS(id)
   tagList(
     
-    # tabbox
-    shinydashboard::tabBox(
-      title = "Dataset Dashboard",
-      width = NULL,
-      side = "right",
-      
-      # show different views of dataset on different tab panels
-      
-      # all unreleased data
-      tabPanel("Unreleased", 
-               DT::DTOutput(ns("unreleased_dash"))),
-      
-      # unreleased, no embargo, passing all checks
-      # aka ready for release
-      tabPanel("Ready for release", 
-               DT::DTOutput(ns("all_checks_passed_dash"))),
-      
-      # released_scheduled = NA
-      tabPanel("Not scheduled", 
-               DT::DTOutput(ns("not_scheduled_dash"))),
-      
-      # all
-      tabPanel("All", 
-               DT::DTOutput(ns("all_dash"))),
-      
-      # released = TRUE
-      tabPanel("Previously released", 
-               DT::DTOutput(ns("released_dash")))
-    )
- 
-  )
-}
+    DT::DTOutput(ns("datatable_out")))
+ }
     
 #' datatable Server Functions
 #'
@@ -58,10 +28,6 @@ mod_datatable_server <- function(id, df){
     # floor date (only care about month/year)
     today <- lubridate::floor_date(today, unit = "month")
     
-    # qc_columns
-    qc_cols <- c("Standard_Compliance", "QC_Compliance", "PHI_Detection_Compliance", 
-                 "Access_Controls_Compliance", "Data_Portal")
-    
     # add a column to df of TRUE/FALSE date is past due
     all_datasets <- reactive({
       data <- df()
@@ -70,76 +36,15 @@ mod_datatable_server <- function(id, df){
                               ifelse(dates == today, "t", NA))
       return(data)
     })
+
+    # render datatable
     
-    # subset dataframe into various views
-    unreleased_datasets <- reactive({
-      data <- all_datasets()
-      data[ data$Released == FALSE, ]
-    })
-    
-    # not scheduled
-    not_scheduled_datasets <- reactive({
-      data <- all_datasets()
-      data[ is.na(data$Release_Scheduled), ]
-    })
-    
-    # all checks passing / no embargo / unreleased (i.e. ready for release)
-    all_checks_passed_datasets <- reactive({
-      data <- all_datasets()
-      
-      # which rows have all qc_cols == TRUE
-      passing <- apply(data[ , qc_cols ], 1, all)
-      
-      # which rows have passed their embargo date or are NA
-      no_embargo <- data$Embargo <= today | is.na(data$Embargo)
-      
-      # which rows are unreleased
-      unreleased <- data$Released == FALSE
-      
-      # which rows are passing qc, past/have no embargo, and are unreleased
-      ready <- passing & no_embargo
-      
-      
-      # subset
-      data[ ready, ]
-    })
-    
-    # previously released
-    released_datasets <- reactive({
-      data <- all_datasets()
-      data[ data$Released == TRUE, ]
-    })
-    
-    # render datatables
-    
-    output$all_dash <- DT::renderDataTable({
+    output$datatable_out <- DT::renderDataTable({
       create_dashboard(
         prep_df_for_dash(all_datasets())
         )
       })
-    
-    output$not_scheduled_dash <- DT::renderDataTable({
-      create_dashboard(
-        prep_df_for_dash(not_scheduled_datasets())
-        )
-    })
-    
-    output$unreleased_dash <- DT::renderDataTable({
-      create_dashboard(
-        prep_df_for_dash(unreleased_datasets())
-      )
-    })
-    
-    output$released_dash <- DT::renderDataTable({
-      create_dashboard(
-        prep_df_for_dash(released_datasets()))
-    })
-    
-    output$all_checks_passed_dash <- DT::renderDataTable({
-      create_dashboard(prep_df_for_dash(all_checks_passed_datasets()))
-    })
-  
-    
+
   })
 }
     

--- a/R/mod_datatable_dashboard.R
+++ b/R/mod_datatable_dashboard.R
@@ -1,4 +1,4 @@
-#' datatable UI Function
+#' datatable_dashboard UI Function
 #'
 #' @description A shiny Module.
 #'
@@ -6,22 +6,22 @@
 #'
 #' @noRd 
 #'
-#' @importFrom shiny NS tagList
-
-mod_datatable_ui <- function(id){
+#' @importFrom shiny NS tagList 
+mod_datatable_dashboard_ui <- function(id){
   ns <- NS(id)
   tagList(
+    DT::DTOutput(ns("datatable_out"))
+  )
+}
     
-    DT::DTOutput(ns("datatable_out")))
- }
-    
-#' datatable Server Functions
+#' datatable_dashboard Server Functions
 #'
 #' @noRd 
-mod_datatable_server <- function(id, df){
+mod_datatable_dashboard_server <- function(id, df){
   moduleServer( id, function(input, output, session){
     ns <- session$ns
     
+    ## FIXME : move this outside of datatable function
     # get todays date
     today <- Sys.Date()
     
@@ -36,20 +36,20 @@ mod_datatable_server <- function(id, df){
                               ifelse(dates == today, "t", NA))
       return(data)
     })
-
+    
     # render datatable
     
     output$datatable_out <- DT::renderDataTable({
       create_dashboard(
         prep_df_for_dash(all_datasets())
-        )
-      })
-
+      )
+    })
+ 
   })
 }
     
 ## To be copied in the UI
-# mod_datatable_ui("datatable_1")
+# mod_datatable_dashboard_ui("datatable_dashboard_1")
     
 ## To be copied in the server
-# mod_datatable_server("datatable_1")
+# mod_datatable_dashboard_server("datatable_dashboard_1")

--- a/R/mod_datatable_dashboard.R
+++ b/R/mod_datatable_dashboard.R
@@ -21,27 +21,11 @@ mod_datatable_dashboard_server <- function(id, df){
   moduleServer( id, function(input, output, session){
     ns <- session$ns
     
-    ## FIXME : move this outside of datatable function
-    # get todays date
-    today <- Sys.Date()
-    
-    # floor date (only care about month/year)
-    today <- lubridate::floor_date(today, unit = "month")
-    
-    # add a column to df of TRUE/FALSE date is past due
-    all_datasets <- reactive({
-      data <- df()
-      dates <- lubridate::floor_date(data$Release_Scheduled, unit = "month")
-      data$past_due <- ifelse(dates < today, "pd", 
-                              ifelse(dates == today, "t", NA))
-      return(data)
-    })
-    
     # render datatable
     
     output$datatable_out <- DT::renderDataTable({
       create_dashboard(
-        prep_df_for_dash(all_datasets())
+        prep_df_for_dash(df())
       )
     })
  

--- a/R/mod_tabbed_dashboard.R
+++ b/R/mod_tabbed_dashboard.R
@@ -1,0 +1,135 @@
+#' tabbed_dashboard UI Function
+#'
+#' @description A shiny Module.
+#'
+#' @param id,input,output,session Internal parameters for {shiny}.
+#'
+#' @noRd 
+#'
+#' @importFrom shiny NS tagList 
+mod_tabbed_dashboard_ui <- function(id){
+  ns <- NS(id)
+  tagList(
+    
+    # tabbox
+    shinydashboard::tabBox(
+      title = "Dataset Dashboard",
+      width = NULL,
+      side = "right",
+      
+      # show different views of dataset on different tab panels
+      
+      # all unreleased data
+      tabPanel("Unreleased", 
+               mod_datatable_dashboard_ui(ns("datatable_dashboard_unreleased"))),
+      
+      # unreleased, no embargo, passing all checks
+      # aka ready for release
+      tabPanel("Ready for release",
+               mod_datatable_dashboard_ui(ns("datatable_dashboard_ready"))),
+
+      # released_scheduled = NA
+      tabPanel("Not scheduled",
+               mod_datatable_dashboard_ui(ns("datatable_dashboard_not_scheduled"))),
+
+      # all
+      tabPanel("All",
+               mod_datatable_dashboard_ui(ns("datatable_dashboard_all"))),
+
+      # released = TRUE
+      tabPanel("Previously released",
+               mod_datatable_dashboard_ui(ns("datatable_dashboard_archive")))
+    )
+  )
+}
+    
+#' tabbed_dashboard Server Functions
+#'
+#' @noRd 
+mod_tabbed_dashboard_server <- function(id, df){
+  moduleServer( id, function(input, output, session){
+    ns <- session$ns
+    
+    # qc_columns
+    qc_cols <- c("Standard_Compliance", "QC_Compliance", "PHI_Detection_Compliance", 
+                 "Access_Controls_Compliance", "Data_Portal")
+    
+    ## FIXME : move this outside of datatable function
+    # get todays date
+    today <- Sys.Date()
+    
+    # floor date (only care about month/year)
+    today <- lubridate::floor_date(today, unit = "month")
+    
+    # add a column to df of TRUE/FALSE date is past due
+    all_datasets <- reactive({
+      data <- df()
+      dates <- lubridate::floor_date(data$Release_Scheduled, unit = "month")
+      data$past_due <- ifelse(dates < today, "pd", 
+                              ifelse(dates == today, "t", NA))
+      return(data)
+    })
+    
+    # subset dataframe into various views
+    unreleased_datasets <- reactive({
+      data <- all_datasets()
+      data[ data$Released == FALSE, ]
+    })
+
+    # not scheduled
+    not_scheduled_datasets <- reactive({
+      data <- all_datasets()
+      data[ is.na(data$Release_Scheduled), ]
+    })
+
+    # all checks passing / no embargo / unreleased (i.e. ready for release)
+    all_checks_passed_datasets <- reactive({
+      data <- all_datasets()
+
+      # which rows have all qc_cols == TRUE
+      passing <- apply(data[ , qc_cols ], 1, all)
+
+      # which rows have passed their embargo date or are NA
+      no_embargo <- data$Embargo <= today | is.na(data$Embargo)
+
+      # which rows are unreleased
+      unreleased <- data$Released == FALSE
+
+      # which rows are passing qc, past/have no embargo, and are unreleased
+      ready <- passing & no_embargo
+
+
+      # subset
+      data[ ready, ]
+    })
+
+    # previously released
+    released_datasets <- reactive({
+      data <- all_datasets()
+      data[ data$Released == TRUE, ]
+    })
+    
+    # render datatables
+    
+    mod_datatable_dashboard_server("datatable_dashboard_all",
+                                   all_datasets)
+    
+    mod_datatable_dashboard_server("datatable_dashboard_unreleased",
+                                   unreleased_datasets)
+    
+    mod_datatable_dashboard_server("datatable_dashboard_not_scheduled",
+                                   not_scheduled_datasets)
+    
+    mod_datatable_dashboard_server("datatable_dashboard_ready",
+                                   all_checks_passed_datasets)
+    
+    mod_datatable_dashboard_server("datatable_dashboard_archive",
+                                   released_datasets)
+  })
+}
+    
+## To be copied in the UI
+# mod_tabbed_dashboard_ui("tabbed_dashboard_1")
+    
+## To be copied in the server
+# mod_tabbed_dashboard_server("tabbed_dashboard_1")


### PR DESCRIPTION
reduce datatable dashboard module.

Initially included five tabs with various subsets of the data. Now dashboard module only contains functions that prep the data and manage `DT::datatable` Javascript styling.

Still quite a bit is hardcoded - this will be addressed as the configs are developed.