### PR TITLE
unschedule dates

### DIFF
--- a/R/mod_scheduler.R
+++ b/R/mod_scheduler.R
@@ -1,0 +1,52 @@
+#' scheduler UI Function
+#'
+#' @description A shiny Module.
+#'
+#' @param id,input,output,session Internal parameters for {shiny}.
+#' @param dateInput_label label for dateInput
+#' @param checkboxInput_label date for checkboxInput
+#'
+#' @noRd 
+#'
+#' @importFrom shiny NS tagList 
+mod_scheduler_ui <- function(id,
+                             dateInput_label,
+                             checkboxInput_label) {
+  ns <- NS(id)
+  tagList(
+    # release scheduled input
+    dateInput(ns("date"), label = dateInput_label, value = NA),
+    checkboxInput(ns("unschedule_chk"), label = checkboxInput_label, value = FALSE))
+}
+    
+#' scheduler Server Functions
+#'
+#' @noRd 
+mod_scheduler_server <- function(id){
+  moduleServer( id, function(input, output, session){
+    ns <- session$ns
+    
+    date_out <- reactive({
+      
+      if (length(input$date) == 0 & input$unschedule_chk == FALSE) {
+        return(NULL)
+      } else if (length(input$date) == 0 & input$unschedule_chk == TRUE) {
+        return(NA)
+      } else if (length(input$date) != 0 & input$unschedule_chk == TRUE) {
+        return(NA)
+      } else {
+        return(input$date)
+      }
+      
+    })
+    
+    return(reactive({ date_out() }))
+ 
+  })
+}
+    
+## To be copied in the UI
+# mod_scheduler_ui("scheduler_1")
+    
+## To be copied in the server
+# mod_scheduler_server("scheduler_1")

--- a/R/mod_scheduler.R
+++ b/R/mod_scheduler.R
@@ -22,7 +22,7 @@ mod_scheduler_ui <- function(id,
     dateInput(ns("date"), label = dateInput_label, value = NA),
     checkboxInput(ns("unschedule_chk"), label = checkboxInput_label, value = FALSE))
 }
-    
+
 #' scheduler Server Functions
 #'
 #' @noRd 
@@ -30,36 +30,53 @@ mod_scheduler_server <- function(id){
   moduleServer( id, function(input, output, session){
     ns <- session$ns
     
+    # on checkbox click
     observeEvent(input$unschedule_chk, {
+      
+      # if the checkbox is clicked:
       if(input$unschedule_chk == TRUE){
+        
+        # update the date input to blank out the date
         updateDateInput(session = session, inputId = "date", value = NA)
+        
+        # use shinyjs to disable the date ui widget
         shinyjs::disable("date")
-        } else {
-          shinyjs::enable("date")
+        
+      } else {
+        
+        # when checkbox is not clicked enable the date box to be used
+        shinyjs::enable("date")
       }
     })
     
     date_out <- reactive({
       
+      # if there is no date selected AND checkbox is not clicked return NULL
       if (length(input$date) == 0 & input$unschedule_chk == FALSE) {
         return(NULL)
-        } else if (length(input$date) == 0 & input$unschedule_chk == TRUE) {
+        
+        # if there is no date selected AND checkbox is clicked return NA (unschedule)
+      } else if (length(input$date) == 0 & input$unschedule_chk == TRUE) {
         return(NA)
-        } else if (length(input$date) != 0 & input$unschedule_chk == TRUE) {
+        
+        # if there is a selected AND checkbox is clicked return NA (unschedule)
+      } else if (length(input$date) != 0 & input$unschedule_chk == TRUE) {
         return(NA)
-        } else {
-          return(input$date)
+        
+        # if there is a selected date and checkbox is not clicked return date
+      } else {
+        return(input$date)
       }
       
     })
     
     return(reactive({ date_out() }))
- 
+    
   })
 }
-    
+
 ## To be copied in the UI
 # mod_scheduler_ui("scheduler_1")
-    
+
 ## To be copied in the server
 # mod_scheduler_server("scheduler_1")

--- a/R/mod_scheduler.R
+++ b/R/mod_scheduler.R
@@ -14,6 +14,10 @@ mod_scheduler_ui <- function(id,
                              checkboxInput_label) {
   ns <- NS(id)
   tagList(
+    
+    # initialize shinyjs 
+    shinyjs::useShinyjs(),
+    
     # release scheduled input
     dateInput(ns("date"), label = dateInput_label, value = NA),
     checkboxInput(ns("unschedule_chk"), label = checkboxInput_label, value = FALSE))
@@ -26,16 +30,25 @@ mod_scheduler_server <- function(id){
   moduleServer( id, function(input, output, session){
     ns <- session$ns
     
+    observeEvent(input$unschedule_chk, {
+      if(input$unschedule_chk == TRUE){
+        updateDateInput(session = session, inputId = "date", value = NA)
+        shinyjs::disable("date")
+        } else {
+          shinyjs::enable("date")
+      }
+    })
+    
     date_out <- reactive({
       
       if (length(input$date) == 0 & input$unschedule_chk == FALSE) {
         return(NULL)
-      } else if (length(input$date) == 0 & input$unschedule_chk == TRUE) {
+        } else if (length(input$date) == 0 & input$unschedule_chk == TRUE) {
         return(NA)
-      } else if (length(input$date) != 0 & input$unschedule_chk == TRUE) {
+        } else if (length(input$date) != 0 & input$unschedule_chk == TRUE) {
         return(NA)
-      } else {
-        return(input$date)
+        } else {
+          return(input$date)
       }
       
     })

--- a/R/mod_update_data_flow_status.R
+++ b/R/mod_update_data_flow_status.R
@@ -15,10 +15,13 @@ mod_update_data_flow_status_ui <- function(id){
       width = NULL,
       
       # release scheduled input
-      dateInput(ns("release_date"), label = h4("Schedule Release"), value = NA),
-      
+      mod_scheduler_ui(ns("release_date"), 
+                       dateInput_label = h4("Schedule Release"),
+                       checkboxInput_label = "Unschedule Release"),
       # embargo input
-      dateInput(ns("embargo_date"), label = h4("Schedule Embargo"), value = NA),
+      mod_scheduler_ui(ns("embargo"), 
+                       dateInput_label = h4("Schedule Embargo"),
+                       checkboxInput_label = "Unschedule Embargo"),
       
       # standard compliance input
       radioButtons(ns("standard_compliance"), 
@@ -49,25 +52,9 @@ mod_update_data_flow_status_server <- function(id){
   moduleServer( id, function(input, output, session){
     ns <- session$ns
     
-    release_scheduled <- reactive({
-      
-      if (length(input$release_date) == 0) {
-        return(NULL)
-      } else {
-        return(input$release_date)
-      }
-      
-    })
-    
-    embargo <- reactive({
-      
-      if (length(input$embargo_date) == 0) {
-        return(NULL)
-      } else {
-        return(input$embargo_date)
-      }
-      
-    })
+    release_scheduled <- mod_scheduler_server("release_date")
+
+    embargo <- mod_scheduler_server("embargo")
     
     res <- reactive({
       list(release_scheduled = release_scheduled(),


### PR DESCRIPTION
Previously could set and change dates through administrator but could not unschedule a date (shows as NA in the manifest) through the dateInput widget.

Use a checkbox to indicate that you want to unschedule a date. Checkbox click will disable date input and update the value to NA.