### PR TITLE
Set up app to use HTAN specific mock data

### DIFF
--- a/R/app_server.R
+++ b/R/app_server.R
@@ -46,6 +46,7 @@ app_server <- function( input, output, session ) {
   
   select_storage_project <- mod_select_storage_project_server(id = "select_storage_project_1",
                                                               asset_view = global_config$asset_view,
+                                                              hidden_storage_projects = "HTAN All Projects",
                                                               input_token = global_config$schematic_token)
   
   # DATASET SELECTION

--- a/R/manifest.R
+++ b/R/manifest.R
@@ -42,6 +42,9 @@ generate_data_flow_manifest <- function(storage_project_id,
     })
     
     num_items <- purrr::flatten_int(num_items_list)
+
+  } else {
+    num_items <- rep("Not Applicable", length(dataset_ids))
   }
   
   # create empty dataframe

--- a/R/manifest.R
+++ b/R/manifest.R
@@ -3,19 +3,18 @@
 #' @export
 
 generate_data_flow_manifest <- function(storage_project_id,
-                                        config,
+                                        asset_view,
+                                        input_token,
                                         contributor = NULL,
+                                        calc_num_items = FALSE,
                                         testing = FALSE) {
-  
-  asset_view <- config$asset_view
-  token <- config$schematic_token
   
   # get all manifests for storage_project
   message(glue::glue("Building data flow status manifest for {storage_project_id}"))
   message("Getting all manifests")
   all_manifests_list <- storage_project_manifests(asset_view, 
                                                   storage_project_id, 
-                                                  token)
+                                                  input_token)
   
   # pull out data from list
   # dataset metadata
@@ -29,19 +28,21 @@ generate_data_flow_manifest <- function(storage_project_id,
   
   # calculate number of items
   # pull down each manifest and count each row (1 file / row)
-  message("Counting items in each manifest")
-  num_items_list <- lapply(dataset_ids, function(id) {
-    manifest <- suppressMessages(manifest_download_to_df(config$asset_view,
-                                        id,
-                                        config$schematic_token))
-    if (!is.null(manifest)) {
-      nrow(manifest)
-    } else {
-      NA
-    }
-  })
-  
-  num_items <- purrr::flatten_int(num_items_list)
+  if (calc_num_items) {
+    message("Counting items in each manifest")
+    num_items_list <- lapply(dataset_ids, function(id) {
+      manifest <- suppressMessages(manifest_download_to_df(asset_view,
+                                                           id,
+                                                           input_token))
+      if (!is.null(manifest)) {
+        nrow(manifest)
+      } else {
+        NA
+      }
+    })
+    
+    num_items <- purrr::flatten_int(num_items_list)
+  }
   
   # create empty dataframe
   colnames <- c("Component", 

--- a/R/mod_dataset_selection.R
+++ b/R/mod_dataset_selection.R
@@ -77,13 +77,15 @@ mod_dataset_selection_server <- function(id,
       # remove specified datasets from being shown 
       if (!is.null(hidden_datasets)) {
        
-        dfs_idx <- match(hidden_datasets, dataset_df$name)
+        idx <- match(hidden_datasets, dataset_df$name)
         
-        dataset_df <- dataset_df[-(dfs_idx),] 
+        # check that specified hidden project exists before attempting subset
+        if (!is.na(idx)) {
+          dataset_df <- dataset_df[-(idx),] 
+        }
       }
        
       dplyr::select(dataset_df, name, id)
-       
        
     })
     

--- a/R/mod_select_storage_project.R
+++ b/R/mod_select_storage_project.R
@@ -29,7 +29,7 @@ mod_select_storage_project_ui <- function(id){
 # Storage Project Selection Module Server
 #'
 #' @noRd 
-mod_select_storage_project_server <- function(id, asset_view, input_token) {
+mod_select_storage_project_server <- function(id, asset_view, hidden_storage_projects, input_token) {
   
   moduleServer( id, function(input, output, session){
     
@@ -48,6 +48,20 @@ mod_select_storage_project_server <- function(id, asset_view, input_token) {
   
     # reorder and add to reactive values
     storage_project_df <- dplyr::select(storage_project_df, name, id)
+    
+    
+    # HIDE STORAGE PROJECTS 
+    
+    # remove specified datasets from being shown 
+    if (!is.null(hidden_storage_projects)) {
+      
+      idx <- match(hidden_storage_projects, storage_project_df$name)
+      
+      # check that specified hidden project exists before attempting subset
+      if (!is.na(idx)) {
+        storage_project_df <- storage_project_df[-(idx),] 
+      }
+    }
     
     # DROP DOWN LISTING STORAGE PROJECTS ####################################################################
     

--- a/inst/global.json
+++ b/inst/global.json
@@ -1,7 +1,7 @@
 {
 
-    "asset_view": "syn23643253",
-    "manifest_dataset_id": "syn34640850",
+    "asset_view": "syn20446927",
+    "manifest_dataset_id": "syn38212343",
     "schematic_token": "token",
     "schema_url": "https://raw.githubusercontent.com/Sage-Bionetworks/data_flow/dev/inst/data_flow_component.jsonld"
   }

--- a/man/generate_data_flow_manifest.Rd
+++ b/man/generate_data_flow_manifest.Rd
@@ -6,8 +6,10 @@
 \usage{
 generate_data_flow_manifest(
   storage_project_id,
-  config,
+  asset_view,
+  input_token,
   contributor = NULL,
+  calc_num_items = FALSE,
   testing = FALSE
 )
 }


### PR DESCRIPTION
Previously the app was running using `schematic - main` mock up data. Moving the app over to test it out using HTAN specific mock up data. This involved:

- generating the HTAN data flow manifest skeleton
- filling the data flow manifest with some mock data
- creating a new DataFlowStatus folder in `HTAN All Projects` and adding it to the master file view
- adjusting the config to point at the HTAN datasets