### PR TITLE
Dashboard filtering

### DIFF
--- a/R/app_server.R
+++ b/R/app_server.R
@@ -120,13 +120,6 @@ app_server <- function( input, output, session ) {
                           x_lab = "Type of dataset",
                           y_lab = "Number of Datasets",
                           fill = "#0d1c38")
-
-  # TOGGLE BETWEEN STACKED BARS #########################################################
-  whichPlot <- reactiveVal(TRUE)
-  
-  observeEvent(input$toggle_stacked_bar, {
-    whichPlot(!whichPlot())
-  })
   
   # PREPARE DATA FOR STACKED BAR PLOTS ##################################################
   # specifically stacked bar plots that show data flow status grouped by contributor
@@ -142,9 +135,6 @@ app_server <- function( input, output, session ) {
     # reorder factors
     release_status_data$data_flow_status <- factor(release_status_data$data_flow_status, 
                                                    levels = c("released", "quarantine (ready for release)", "quarantine", "not scheduled"))
-    if (whichPlot() == FALSE) {
-      release_status_data <- release_status_data[release_status_data$data_flow_status != "not scheduled",]
-    }
     
     release_status_data
   })
@@ -174,7 +164,7 @@ app_server <- function( input, output, session ) {
   # wrangle data for stacked bar plot (runners)
   
   release_data_runners <- reactive({
-    
+
     release_status_data <- manifest_w_status() %>%
       dplyr::filter(!is.na(release_scheduled)) %>%
       dplyr::filter(contributor == input$select_project_input) %>%

--- a/R/app_server.R
+++ b/R/app_server.R
@@ -138,13 +138,6 @@ app_server <- function( input, output, session ) {
     
     release_status_data
   })
-  
-  # wrangle data for stacked bar plot (only scheduled)
-  release_status_data_scheduled <- reactive({
-
-    release_status_data()[release_status_data()$data_flow_status != "not scheduled",]
-  })
-  
 
   whichPlot <- reactiveVal(TRUE)
   

--- a/R/app_server.R
+++ b/R/app_server.R
@@ -23,8 +23,8 @@ app_server <- function( input, output, session ) {
   
   # download data flow status manifest
   synapse_manifest <- manifest_download_to_df(asset_view = global_config$asset_view,
-                                          dataset_id = global_config$manifest_dataset_id,
-                                          input_token = global_config$schematic_token)
+                                              dataset_id = global_config$manifest_dataset_id,
+                                              input_token = global_config$schematic_token)
   
   manifest_dfa <- prep_manifest_dfa(manifest = synapse_manifest,
                                     config = dash_config)
@@ -72,12 +72,14 @@ app_server <- function( input, output, session ) {
 
     contributor_choices <- unique(manifest_w_status()$contributor)
     dataset_choices <- unique(manifest_w_status()$dataset)
-    release_daterange_start <- min(manifest_w_status()$release_scheduled)
-    release_daterange_end <- max(manifest_w_status()$release_scheduled)
+    release_daterange_start <- min(manifest_w_status()$release_scheduled, na.rm = TRUE)
+    release_daterange_end <- max(manifest_w_status()$release_scheduled, na.rm = TRUE)
     status_choices <- unique(manifest_w_status()$data_flow_status)
     
     list(contributor_choices, 
          dataset_choices,
+         release_daterange_start,
+         release_daterange_end,
          status_choices)
   })
   
@@ -86,8 +88,8 @@ app_server <- function( input, output, session ) {
     mod_datatable_filters_ui("datatable_filters_1",
                              contributor_choices = filters[[1]],
                              dataset_choices = filters[[2]],
-                             release_daterange = c(as.Date(NA), as.Date(NA)),
-                             status_choices = filters[[3]])
+                             release_daterange = c(filters[[3]], filters[[4]]),
+                             status_choices = filters[[5]])
   })
   
   # FILTER MANIFEST FOR DASH SERVER  ####################################################

--- a/R/app_server.R
+++ b/R/app_server.R
@@ -153,7 +153,7 @@ app_server <- function( input, output, session ) {
   # drop down for runners plot
   output$select_project_ui <- shiny::renderUI({
     
-    contributors <- unique(manifest_w_status()$contributor)
+    contributors <- unique(filtered_manifest()$contributor)
     
     shiny::selectInput(inputId = "select_project_input",
                        label = NULL,
@@ -164,8 +164,10 @@ app_server <- function( input, output, session ) {
   # wrangle data for stacked bar plot (runners)
   
   release_data_runners <- reactive({
-
-    release_status_data <- manifest_w_status() %>%
+    
+    req(input$select_project_input)
+  
+    release_status_data <- filtered_manifest() %>%
       dplyr::filter(!is.na(release_scheduled)) %>%
       dplyr::filter(contributor == input$select_project_input) %>%
       dplyr::group_by(contributor) %>%

--- a/R/app_server.R
+++ b/R/app_server.R
@@ -16,7 +16,7 @@ app_server <- function( input, output, session ) {
   syntab <- reticulate::import("synapseclient.table")
   syn <- synapseclient$Synapse()
   syn$login()
-  
+
   # read in configs
   global_config <- jsonlite::read_json("inst/global.json")
   dash_config <- jsonlite::read_json("inst/datatable_dashboard_config.json")
@@ -29,7 +29,7 @@ app_server <- function( input, output, session ) {
   manifest_dfa <- prep_manifest_dfa(manifest = synapse_manifest,
                                     config = dash_config)
   
-  # PREPARE MANIFEST FOR DASH ####################################################################
+  # PREPARE MANIFEST FOR DASH ###########################################################
   
   # add status to manifest
   manifest_w_status <- reactive({
@@ -65,7 +65,7 @@ app_server <- function( input, output, session ) {
     manifest
   })
   
-  # FILTER MANIFEST FOR DASH  ###########################################################
+  # FILTER MANIFEST FOR DASH UI ###########################################################
   
   # prepare inputs for filter module
   filter_inputs <- reactive({
@@ -90,13 +90,17 @@ app_server <- function( input, output, session ) {
                              status_choices = filters[[3]])
   })
   
+  # FILTER MANIFEST FOR DASH SERVER  ####################################################
+  filtered_manifest <- mod_datatable_filters_server("datatable_filters_1",
+                                                    reactive({manifest_dfa}))
+  
 
   # DATASET DASH  #######################################################################
   
   # create dashboard
   
   mod_datatable_dashboard_server("dashboard_1",
-                                 reactive({manifest_dfa}),
+                                 filtered_manifest,
                                  jsonlite::read_json("inst/datatable_dashboard_config.json"))
   
   # DATASET DASH VIZ : DISTRIBUTIONS ####################################################

--- a/R/app_server.R
+++ b/R/app_server.R
@@ -8,14 +8,6 @@ app_server <- function( input, output, session ) {
   # Your application server logic
   
   # DEV STUFF ###########################################################################
-  
-  # SYNAPSE LOGIN
-  # TODO: log in will eventually live in global.R/rely on config info
-  reticulate::use_virtualenv(".venv/")
-  synapseclient <- reticulate::import("synapseclient")
-  syntab <- reticulate::import("synapseclient.table")
-  syn <- synapseclient$Synapse()
-  syn$login()
 
   # read in configs
   global_config <- jsonlite::read_json("inst/global.json")

--- a/R/app_server.R
+++ b/R/app_server.R
@@ -92,7 +92,7 @@ app_server <- function( input, output, session ) {
   
   # FILTER MANIFEST FOR DASH SERVER  ####################################################
   filtered_manifest <- mod_datatable_filters_server("datatable_filters_1",
-                                                    reactive({manifest_dfa}))
+                                                    manifest_w_status)
   
 
   # DATASET DASH  #######################################################################
@@ -131,7 +131,7 @@ app_server <- function( input, output, session ) {
   
   stacked_bar_data <- reactive({
 
-    release_status_data <- manifest_w_status() %>%
+    release_status_data <- filtered_manifest() %>%
       dplyr::group_by(contributor) %>%
       dplyr::group_by(dataset, .add = TRUE) %>%
       dplyr::group_by(data_flow_status, .add = TRUE) %>%

--- a/R/app_server.R
+++ b/R/app_server.R
@@ -106,7 +106,7 @@ app_server <- function( input, output, session ) {
   # DATASET DASH VIZ : DISTRIBUTIONS ####################################################
   
   mod_distribution_server(id = "distribution_contributor",
-                          df = manifest_dfa,
+                          df = filtered_manifest,
                           group_by_var = "contributor",
                           title = NULL,
                           x_lab = "Contributor",
@@ -114,7 +114,7 @@ app_server <- function( input, output, session ) {
                           fill = "#0d1c38")
   
   mod_distribution_server(id = "distribution_datatype",
-                          df = manifest_dfa,
+                          df = filtered_manifest,
                           group_by_var = "dataset",
                           title = NULL,
                           x_lab = "Type of dataset",
@@ -141,11 +141,11 @@ app_server <- function( input, output, session ) {
   
   # wrangle data for stacked bar plot (only scheduled)
   release_status_data_scheduled <- reactive({
-    
+
     release_status_data()[release_status_data()$data_flow_status != "not scheduled",]
   })
   
-  
+
   whichPlot <- reactiveVal(TRUE)
   
   observeEvent(input$toggle_stacked_bar, {

--- a/R/app_server.R
+++ b/R/app_server.R
@@ -67,6 +67,28 @@ app_server <- function( input, output, session ) {
   
   # FILTER MANIFEST FOR DASH  ###########################################################
   
+  # prepare inputs for filter module
+  filter_inputs <- reactive({
+
+    contributor_choices <- unique(manifest_w_status()$contributor)
+    dataset_choices <- unique(manifest_w_status()$dataset)
+    release_daterange_start <- min(manifest_w_status()$release_scheduled)
+    release_daterange_end <- max(manifest_w_status()$release_scheduled)
+    status_choices <- unique(manifest_w_status()$data_flow_status)
+    
+    list(contributor_choices, 
+         dataset_choices,
+         status_choices)
+  })
+  
+  output$filter_module <- renderUI({
+    filters <- filter_inputs()
+    mod_datatable_filters_ui("datatable_filters_1",
+                             contributor_choices = filters[[1]],
+                             dataset_choices = filters[[2]],
+                             release_daterange = c(as.Date(NA), as.Date(NA)),
+                             status_choices = filters[[3]])
+  })
   
 
   # DATASET DASH  #######################################################################

--- a/R/app_server.R
+++ b/R/app_server.R
@@ -97,8 +97,6 @@ app_server <- function( input, output, session ) {
 
   # DATASET DASH  #######################################################################
   
-  # create dashboard
-  
   mod_datatable_dashboard_server("dashboard_1",
                                  filtered_manifest,
                                  jsonlite::read_json("inst/datatable_dashboard_config.json"))
@@ -121,31 +119,17 @@ app_server <- function( input, output, session ) {
                           y_lab = "Number of Datasets",
                           fill = "#0d1c38")
 
-  # DATASET DASH VIZ : DISTRIBUTIONS ####################################################
-  
-  # wrangle data for stacked bar plot
-  release_status_data <- reactive({
-    
-    release_status_data <- manifest_w_status() %>%
-      dplyr::group_by(contributor) %>%
-      dplyr::group_by(dataset, .add = TRUE) %>%
-      dplyr::group_by(data_flow_status, .add = TRUE) %>%
-      dplyr::tally()
-    
-    # reorder factors
-    release_status_data$data_flow_status <- factor(release_status_data$data_flow_status, 
-                                                   levels = c("released", "quarantine (ready for release)", "quarantine", "not scheduled"))
-    
-    release_status_data
-  })
-
+  # TOGGLE BETWEEN STACKED BARS #########################################################
   whichPlot <- reactiveVal(TRUE)
   
   observeEvent(input$toggle_stacked_bar, {
     whichPlot(!whichPlot())
   })
   
-  which_release_data <- reactive({
+  # PREPARE DATA FOR STACKED BAR PLOTS ##################################################
+  # specifically stacked bar plots that show data flow status grouped by contributor
+  
+  stacked_bar_data <- reactive({
 
     release_status_data <- manifest_w_status() %>%
       dplyr::group_by(contributor) %>%
@@ -164,7 +148,7 @@ app_server <- function( input, output, session ) {
   })
   
   mod_stacked_bar_server(id = "stacked_bar_release_status",
-                         df = which_release_data,
+                         df = stacked_bar_data,
                          x_var = "contributor",
                          y_var = "n",
                          fill_var = "data_flow_status",
@@ -217,7 +201,7 @@ app_server <- function( input, output, session ) {
                          width = 10,
                          date_breaks = "1 month",
                          coord_flip = FALSE)
-
+  
   # ADMINISTRATOR  #######################################################################
   
   # reactive value that holds manifest_dfa 

--- a/R/app_server.R
+++ b/R/app_server.R
@@ -34,9 +34,9 @@ app_server <- function( input, output, session ) {
   
   # create tabbed dashboard
   
-  mod_tabbed_dashboard_server("tabbed_dashboard_1", 
-                              reactive({dfs_manifest}),
-                              jsonlite::read_json("inst/datatable_dashboard_config.json"))
+  mod_datatable_dashboard_server("dashboard_1",
+                                 reactive({dfs_manifest}),
+                                 jsonlite::read_json("inst/datatable_dashboard_config.json"))
   
   # DATASET DASH VIZ : DISTRIBUTIONS ####################################################
   

--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -74,8 +74,7 @@ app_ui <- function(request) {
                                       title = "Distribution of datasets by contributor",
                                       status = "primary",
                                       collapsible = TRUE,
-                                      mod_distribution_ui("distribution_contributor")
-                                      ),
+                                      mod_distribution_ui("distribution_contributor")),
                                     shinydashboard::box(
                                       title = "Distribution of datasets by data type",
                                       status = "primary",
@@ -85,23 +84,19 @@ app_ui <- function(request) {
                                   
                                   shiny::fluidRow(
                                     shinydashboard::box(
-                                      title = "Release status of all datasets by contributor",
-                                      status = "primary",
-                                      collapsible = TRUE,
-                                      mod_stacked_bar_ui("stacked_bar_release_status"),
-                                      br(),
-                                      actionButton("toggle_stacked_bar", "All / Scheduled Only")
-                                      ),
-                                    shinydashboard::box(
-                                      title = "Data flow status by release date",
-                                      status = "primary",
-                                      collapsible = TRUE,
-                                      
-                                      shiny::uiOutput("select_project_ui"),
-                                      
-                                      mod_stacked_bar_ui("stacked_runners")
-                                    )
-                                  )),
+                                    title = "Release status of all datasets by contributor",
+                                    status = "primary",
+                                    collapsible = TRUE,
+                                    mod_stacked_bar_ui("stacked_bar_release_status")),                                   
+                                  shinydashboard::box(
+                                    title = "Data flow status by release date",
+                                    status = "primary",
+                                    collapsible = TRUE,
+                                    
+                                    shiny::uiOutput("select_project_ui"),
+                                    
+                                    mod_stacked_bar_ui("stacked_runners")))
+                                  ),
           
           # Administrator tab
           shinydashboard::tabItem(tabName = "administrator",

--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -57,7 +57,8 @@ app_ui <- function(request) {
           shinydashboard::tabItem(tabName = "dataset-dashboard",
                                   
                                   shiny::fluidRow(
-                                    uiOutput("filter_module")                                    ),
+                                    uiOutput("filter_module")),
+                                  
                                   
                                   shiny::fluidRow(
                                     shinydashboard::box(

--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -55,6 +55,10 @@ app_ui <- function(request) {
           
           # dataset view dashboard tab
           shinydashboard::tabItem(tabName = "dataset-dashboard",
+                                  
+                                  shiny::fluidRow(
+                                    uiOutput("filter_module")                                    ),
+                                  
                                   shiny::fluidRow(
                                     mod_datatable_dashboard_ui("dashboard_1")
                                     ),

--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -60,18 +60,25 @@ app_ui <- function(request) {
                                     uiOutput("filter_module")                                    ),
                                   
                                   shiny::fluidRow(
-                                    mod_datatable_dashboard_ui("dashboard_1")
-                                    ),
+                                    shinydashboard::box(
+                                      width = NULL,
+                                      title = "Dashboard",
+                                      status = "primary",
+                                      collapsible = TRUE,
+                                      mod_datatable_dashboard_ui("dashboard_1")
+                                    )),
                                   
                                   shiny::fluidRow(
                                     shinydashboard::box(
                                       title = "Distribution of datasets by contributor",
                                       status = "primary",
+                                      collapsible = TRUE,
                                       mod_distribution_ui("distribution_contributor")
                                       ),
                                     shinydashboard::box(
                                       title = "Distribution of datasets by data type",
                                       status = "primary",
+                                      collapsible = TRUE,
                                       mod_distribution_ui("distribution_datatype")
                                     )),
                                   
@@ -79,6 +86,7 @@ app_ui <- function(request) {
                                     shinydashboard::box(
                                       title = "Release status of all datasets by contributor",
                                       status = "primary",
+                                      collapsible = TRUE,
                                       mod_stacked_bar_ui("stacked_bar_release_status"),
                                       br(),
                                       actionButton("toggle_stacked_bar", "All / Scheduled Only")
@@ -86,6 +94,7 @@ app_ui <- function(request) {
                                     shinydashboard::box(
                                       title = "Data flow status by release date",
                                       status = "primary",
+                                      collapsible = TRUE,
                                       
                                       shiny::uiOutput("select_project_ui"),
                                       

--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -56,7 +56,7 @@ app_ui <- function(request) {
           # dataset view dashboard tab
           shinydashboard::tabItem(tabName = "dataset-dashboard",
                                   shiny::fluidRow(
-                                    mod_tabbed_dashboard_ui("tabbed_dashboard_1")
+                                    mod_datatable_dashboard_ui("dashboard_1")
                                     ),
                                   
                                   shiny::fluidRow(

--- a/R/datatable_functions.R
+++ b/R/datatable_functions.R
@@ -65,11 +65,12 @@ style_dashboard <- function(prepped_manifest,
   dt <- DT::datatable(prepped_manifest,
                       escape = FALSE, 
                       selection = "none",
-                      filter = "top",
+                      filter = "none",
                       colnames = colnames,
                       options = list(scrollX = TRUE,
                                      scrollY = 500,
                                      bPaginate = FALSE,
+                                     searching = FALSE,
                                      columnDefs = defs))
   
   # FIXME: this is still hardcoded

--- a/R/mod_datatable_filters.R
+++ b/R/mod_datatable_filters.R
@@ -39,7 +39,8 @@ mod_datatable_filters_ui <- function(id,
                         
                         shiny::checkboxGroupInput(ns("choose_status_checkbox"),
                                                   label = "Filter by status",
-                                                  choices = status_choices)
+                                                  choices = status_choices,
+                                                  selected = status_choices)
                         )
   )
 }
@@ -68,7 +69,9 @@ mod_datatable_filters_server <- function(id,
       
       filtered <- manifest %>%
         dplyr::filter(contributor %in% input$contributor_select,
-                      dataset %in% selected_datasets_modified())
+                      dataset %in% selected_datasets_modified(),
+                      release_scheduled > input$release_scheduled_daterange[1] & release_scheduled < input$release_scheduled_daterange[2] | is.na(release_scheduled),     
+                      data_flow_status %in% input$choose_status_checkbox)
       
       
       return(filtered)

--- a/R/mod_datatable_filters.R
+++ b/R/mod_datatable_filters.R
@@ -1,0 +1,85 @@
+#' datatable_filters UI Function
+#'
+#' @description A shiny Module.
+#'
+#' @param id,input,output,session Internal parameters for {shiny}.
+#'
+#' @noRd 
+#'
+#' @importFrom shiny NS tagList 
+mod_datatable_filters_ui <- function(id,
+                                     width = NULL,
+                                     contributor_choices = c("Contributor 1", "Contributor 2"),
+                                     dataset_choices = c("dataset 1", "dataset 2"),
+                                     release_daterange = c(Sys.Date(), (Sys.Date() + 365)),
+                                     status_choices = c("status 1", "status 2")){
+  ns <- NS(id)
+  tagList(
+    shinydashboard::box(title = "Filter Datasets",
+                        collapsible = TRUE,
+                        collapsed = TRUE,
+                        width = width,
+                        
+                        shiny::selectInput(ns("contributor_select"),
+                                           label = "Filter by contributor(s)",
+                                           choices = contributor_choices,
+                                           selected = contributor_choices,
+                                           multiple = TRUE),
+                        
+                        shiny::selectInput(ns("dataset_select"),
+                                           label = "Filter by dataset type(s)",
+                                           choices = dataset_choices,
+                                           selected = dataset_choices,
+                                           multiple = TRUE),
+
+                        shiny::dateRangeInput(ns("release_scheduled_daterange"),
+                                              label = "Filter by release scheduled date range",
+                                              start = release_daterange[1], 
+                                              end = release_daterange[2]),
+                        
+                        shiny::checkboxGroupInput(ns("choose_status_checkbox"),
+                                                  label = "Filter by status",
+                                                  choices = status_choices)
+                        )
+  )
+}
+    
+#' datatable_filters Server Functions
+#'
+#' @noRd 
+mod_datatable_filters_server <- function(id,
+                                         manifest){
+  
+  moduleServer(id, function(input, output, session) {
+    ns <- session$ns
+    
+    # CHANGE "NA" TO NA --------
+    selected_datasets_modified <- reactive({
+      # replace string "NA" with true NA 
+      datasets <- input$dataset_select
+      datasets[datasets == "NA"] <- NA
+      datasets
+    })
+    
+    
+    # FILTER INPUTS ---------
+    manifest_filtered <- reactive({
+      manifest <- manifest()
+      
+      filtered <- manifest %>%
+        dplyr::filter(contributor %in% input$contributor_select,
+                      dataset %in% selected_datasets_modified())
+      
+      
+      return(filtered)
+    })
+    
+    return(manifest_filtered)
+  })
+}
+    
+## To be copied in the UI
+# mod_datatable_filters_ui("datatable_filters_1")
+    
+## To be copied in the server
+# mod_datatable_filters_server("datatable_filters_1")

--- a/R/mod_datatable_filters.R
+++ b/R/mod_datatable_filters.R
@@ -71,7 +71,7 @@ mod_datatable_filters_server <- function(id,
       filtered <- manifest %>%
         dplyr::filter(contributor %in% input$contributor_select,
                       dataset %in% selected_datasets_modified(),
-                      release_scheduled > input$release_scheduled_daterange[1] & release_scheduled < input$release_scheduled_daterange[2] | is.na(release_scheduled),     
+                      release_scheduled > input$release_scheduled_daterange[1] & release_scheduled < input$release_scheduled_daterange[2] || is.na(release_scheduled),     
                       data_flow_status %in% input$choose_status_checkbox)
       
       

--- a/R/mod_datatable_filters.R
+++ b/R/mod_datatable_filters.R
@@ -19,6 +19,7 @@ mod_datatable_filters_ui <- function(id,
                         collapsible = TRUE,
                         collapsed = TRUE,
                         width = width,
+                        status = "primary",
                         
                         shiny::selectInput(ns("contributor_select"),
                                            label = "Filter by contributor(s)",

--- a/R/mod_distribution.R
+++ b/R/mod_distribution.R
@@ -35,28 +35,35 @@ mod_distribution_server <- function(id,
   moduleServer( id, function(input, output, session){
     ns <- session$ns
     
-    #df <- df()
+    grouped_data <- reactive({
+      df <- df()
+      
+      # group and tally data
+      df %>%
+        dplyr::group_by(.data[[group_by_var]]) %>%
+        dplyr::tally()
+    })
     
-    # group and tally data
-    plot_df <- df %>%
-      dplyr::group_by(.data[[group_by_var]]) %>%
-      dplyr::tally()
+    
     
     # create distribution plot
-    dist <- ggplot2::ggplot(plot_df,
-                            ggplot2::aes(x = reorder(.data[[group_by_var]], -n, ), y = n)) +
-      
-      ggplot2::geom_bar(stat = "identity", fill = fill) +
-      
-      ggplot2::labs(title = title, x = x_lab, y = y_lab) +
-      
-      ggplot2::theme_minimal() +
-      
-      ggplot2::theme(axis.text.x = ggplot2::element_text(angle=90,hjust=1)) 
+    dist <- reactive({
+      plot_df <- grouped_data()
+      ggplot2::ggplot(plot_df,
+                      ggplot2::aes(x = reorder(.data[[group_by_var]], -n, ), y = n)) +
+        
+        ggplot2::geom_bar(stat = "identity", fill = fill) +
+        
+        ggplot2::labs(title = title, x = x_lab, y = y_lab) +
+        
+        ggplot2::theme_minimal() +
+        
+        ggplot2::theme(axis.text.x = ggplot2::element_text(angle=90,hjust=1)) 
+    })
     
     # render plot
     output$distribution_plot <- shiny::renderPlot({
-      dist
+      dist()
     })
   })
 }


### PR DESCRIPTION
Move all filtering for the dashboard and plotting modules to its own filtering module. This frees the app from relying on the simplistic `DT::datatable` filtering capabilities.