### PR TITLE
FDS-476 source schematic api url from environment

### DIFF
--- a/.github/workflows/shinyapps_deploy.yml
+++ b/.github/workflows/shinyapps_deploy.yml
@@ -9,7 +9,6 @@ on:
     branches:
       - main
       - dev*
-      - FDS* #FOR TESTING ONLY
     tags:
       - v[0-9]+.[0-9]+.[0-9]+
 

--- a/.github/workflows/shinyapps_deploy.yml
+++ b/.github/workflows/shinyapps_deploy.yml
@@ -30,17 +30,15 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y pip libcurl4-openssl-dev libpng-dev libfontconfig1-dev libharfbuzz-dev libfribidi-dev libtiff-dev libxml2-dev
-        # this action checks out the $GITHUB_WORKSPACE repository so that the workflow can access it
+        
+      # this action checks out the $GITHUB_WORKSPACE repository so that the workflow can access it
       - uses: actions/checkout@v3
-        # this action sets up pandoc
+        
+      # this action sets up pandoc
       - uses: r-lib/actions/setup-pandoc@v2
-        # this action activates renv
+        
+      # this action activates renv
       - uses: r-lib/actions/setup-renv@v2
-        # Write synapse config (not sure if I even need this??)
-      - name: Set Configurations
-        shell: bash
-        run: |
-          echo "${{ secrets.SCHEMATIC_SYNAPSE_CONFIG }}" > .synapseConfig
         # deploy app using rsconnect
       - name: Authorize and deploy app
         run: |
@@ -51,7 +49,9 @@ jobs:
           repo <- Sys.getenv("GITHUB_REPOSITORY")
           appName <- strsplit(repo, "/")[[1]][2]
 
-          # if tag is v*.*.*, deploy to prod, if main to staging, otherwise to test
+          # if tag is v*.*.*, deploy to prod
+          # if main to staging
+          # otherwise to test
           if (grepl("v[0-9]+.[0-9]+.[0-9]+", refName)) {
             message("Deploying release version of app")
           } else if (refName == "main") {
@@ -64,6 +64,7 @@ jobs:
 
           message(sprintf("Deploying to %s instance.", appName))
 
+          # assign secrets to variables
           rsConnectUser <-"${{ secrets.RSCONNECT_USER }}"
           rsConnectToken <- "${{ secrets.RSCONNECT_TOKEN }}"
           rsConnectSecret <- "${{ secrets.RSCONNECT_SECRET }}"
@@ -74,15 +75,17 @@ jobs:
           appUrl<- sprintf("https://%s.shinyapps.io/%s", rsConnectUser, appName)
           config <- c(config, sprintf("app_url: %s", appUrl))
          
+          # write config file
           configFileConn<-file("oauth_config.yml")
           tryCatch(
              writeLines(config, configFileConn),
              finally=close(configFileConn)
           )
-          # FIXME ADD size parameter
+
+          # set account info
           rsconnect::setAccountInfo(rsConnectUser, rsConnectToken, rsConnectSecret)
           
-          # Get app names. If app exists, configure then deploy. Otherwise
+          # get app names. If app exists, configure then deploy. Otherwise
           # deploy then configure.
           apps <- rsconnect::applications()$name
           if (appName %in% apps) {

--- a/.github/workflows/shinyapps_deploy.yml
+++ b/.github/workflows/shinyapps_deploy.yml
@@ -9,6 +9,7 @@ on:
     branches:
       - main
       - dev*
+      - FDS* #FOR TESTING ONLY
     tags:
       - v[0-9]+.[0-9]+.[0-9]+
 
@@ -57,14 +58,14 @@ jobs:
           # otherwise to test
           if (grepl("v[0-9]+.[0-9]+.[0-9]+", refName)) {
             message("Deploying release version of app")
-            Sys.setenv(API_URL = $SCHEMATIC_URL_PROD)
+            Sys.setenv(API_URL = "$SCHEMATIC_URL_PROD")
           } else if (refName == "main") {
             appName <- paste(appName, "staging", sep = "-")
-            Sys.setenv(API_URL = $SCHEMATIC_URL_STAGING)
+            Sys.setenv(API_URL = "$SCHEMATIC_URL_STAGING")
             message("Deploying staging version of app")
           } else {
             appName <- paste(appName, "testing", sep = "-")
-            Sys.setenv(API_URL = $SCHEMATIC_URL_DEV)
+            Sys.setenv(API_URL = "$SCHEMATIC_URL_DEV")
             message("Deploying testing version of app")
           }
 

--- a/.github/workflows/shinyapps_deploy.yml
+++ b/.github/workflows/shinyapps_deploy.yml
@@ -58,17 +58,21 @@ jobs:
           # otherwise to test
           if (grepl("v[0-9]+.[0-9]+.[0-9]+", refName)) {
             message("Deploying release version of app using schematic API production instance")
-            Sys.setenv(DFA_SCHEMATIC_API_URL = "${{ env.SCHEMATIC_URL_PROD }}")
+            renviron <- "DFA_SCHEMATIC_API_URL = '${{ env.SCHEMATIC_URL_PROD }}'"
           } else if (refName == "main") {
             appName <- paste(appName, "staging", sep = "-")
-            Sys.setenv(DFA_SCHEMATIC_API_URL = "${{ env.SCHEMATIC_URL_STAGING }}")
+            renviron <- "DFA_SCHEMATIC_API_URL = '${{ env.SCHEMATIC_URL_STAGING }}'"
             message("Deploying staging version of app using schematic API staging instance")
           } else {
             appName <- paste(appName, "testing", sep = "-")
-            Sys.setenv(DFA_SCHEMATIC_API_URL = "${{ env.SCHEMATIC_URL_DEV }}")
+            renviron <- "DFA_SCHEMATIC_API_URL = '${{ env.SCHEMATIC_URL_DEV }}'"
             message("Deploying testing version of app using schematic API dev instance")
           }
 
+          # write .Renviron
+          writeLines(renviron, ".Renviron") 
+
+          # deploy
           message(sprintf("Deploying to %s instance.", appName))
 
           # assign secrets to variables

--- a/.github/workflows/shinyapps_deploy.yml
+++ b/.github/workflows/shinyapps_deploy.yml
@@ -58,14 +58,14 @@ jobs:
           # otherwise to test
           if (grepl("v[0-9]+.[0-9]+.[0-9]+", refName)) {
             message("Deploying release version of app using schematic API production instance")
-            Sys.setenv(API_URL = "${{ env.SCHEMATIC_URL_PROD }}")
+            Sys.setenv(DFA_SCHEMATIC_API_URL = "${{ env.SCHEMATIC_URL_PROD }}")
           } else if (refName == "main") {
             appName <- paste(appName, "staging", sep = "-")
-            Sys.setenv(API_URL = "${{ env.SCHEMATIC_URL_STAGING }}")
+            Sys.setenv(DFA_SCHEMATIC_API_URL = "${{ env.SCHEMATIC_URL_STAGING }}")
             message("Deploying staging version of app using schematic API staging instance")
           } else {
             appName <- paste(appName, "testing", sep = "-")
-            Sys.setenv(API_URL = "${{ env.SCHEMATIC_URL_DEV }}")
+            Sys.setenv(DFA_SCHEMATIC_API_URL = "${{ env.SCHEMATIC_URL_DEV }}")
             message("Deploying testing version of app using schematic API dev instance")
           }
 

--- a/.github/workflows/shinyapps_deploy.yml
+++ b/.github/workflows/shinyapps_deploy.yml
@@ -70,7 +70,7 @@ jobs:
           }
 
           message(sprintf("Deploying to %s instance.", appName))
-          message(Sys.getenv())
+          print(Sys.getenv())
 
           # assign secrets to variables
           rsConnectUser <-"${{ secrets.RSCONNECT_USER }}"

--- a/.github/workflows/shinyapps_deploy.yml
+++ b/.github/workflows/shinyapps_deploy.yml
@@ -58,19 +58,19 @@ jobs:
           # otherwise to test
           if (grepl("v[0-9]+.[0-9]+.[0-9]+", refName)) {
             message("Deploying release version of app")
-            Sys.setenv(API_URL = "$SCHEMATIC_URL_PROD")
+            Sys.setenv(API_URL = "${{ env.SCHEMATIC_URL_PROD }}")
           } else if (refName == "main") {
             appName <- paste(appName, "staging", sep = "-")
-            Sys.setenv(API_URL = "$SCHEMATIC_URL_STAGING")
+            Sys.setenv(API_URL = "${{ env.SCHEMATIC_URL_STAGING }}")
             message("Deploying staging version of app")
           } else {
             appName <- paste(appName, "testing", sep = "-")
-            Sys.setenv(API_URL = "$SCHEMATIC_URL_DEV")
+            Sys.setenv(API_URL = "${{ env.SCHEMATIC_URL_DEV }}")
             message("Deploying testing version of app")
           }
 
           message(sprintf("Deploying to %s instance.", appName))
-          print(Sys.getenv())
+          message(Sys.getenv())
 
           # assign secrets to variables
           rsConnectUser <-"${{ secrets.RSCONNECT_USER }}"

--- a/.github/workflows/shinyapps_deploy.yml
+++ b/.github/workflows/shinyapps_deploy.yml
@@ -22,6 +22,9 @@ jobs:
     runs-on: ubuntu-latest
     container: rocker/rstudio:4.1.2
     env:
+      SCHEMATIC_URL_DEV: https://schematic-dev.api.sagebionetworks.org/v1/ui/
+      SCHEMATIC_URL_STAGING: https://schematic-staging.api.sagebionetworks.org/v1/ui/
+      SCHEMATIC_URL_PROD: https://schematic.api.sagebionetworks.org/v1/ui/
       # This should not be necessary for installing from public repo's however remotes::install_github() fails without it.
       GITHUB_PAT:  ${{ secrets.GITHUB_TOKEN }}
 
@@ -54,11 +57,14 @@ jobs:
           # otherwise to test
           if (grepl("v[0-9]+.[0-9]+.[0-9]+", refName)) {
             message("Deploying release version of app")
+            Sys.setenv(API_URL = $SCHEMATIC_URL_PROD)
           } else if (refName == "main") {
             appName <- paste(appName, "staging", sep = "-")
+            Sys.setenv(API_URL = $SCHEMATIC_URL_STAGING)
             message("Deploying staging version of app")
           } else {
             appName <- paste(appName, "testing", sep = "-")
+            Sys.setenv(API_URL = $SCHEMATIC_URL_DEV)
             message("Deploying testing version of app")
           }
 

--- a/.github/workflows/shinyapps_deploy.yml
+++ b/.github/workflows/shinyapps_deploy.yml
@@ -57,20 +57,19 @@ jobs:
           # if main to staging
           # otherwise to test
           if (grepl("v[0-9]+.[0-9]+.[0-9]+", refName)) {
-            message("Deploying release version of app")
+            message("Deploying release version of app using schematic API production instance")
             Sys.setenv(API_URL = "${{ env.SCHEMATIC_URL_PROD }}")
           } else if (refName == "main") {
             appName <- paste(appName, "staging", sep = "-")
             Sys.setenv(API_URL = "${{ env.SCHEMATIC_URL_STAGING }}")
-            message("Deploying staging version of app")
+            message("Deploying staging version of app using schematic API staging instance")
           } else {
             appName <- paste(appName, "testing", sep = "-")
             Sys.setenv(API_URL = "${{ env.SCHEMATIC_URL_DEV }}")
-            message("Deploying testing version of app")
+            message("Deploying testing version of app using schematic API dev instance")
           }
 
           message(sprintf("Deploying to %s instance.", appName))
-          print(Sys.getenv())
 
           # assign secrets to variables
           rsConnectUser <-"${{ secrets.RSCONNECT_USER }}"

--- a/R/app_server.R
+++ b/R/app_server.R
@@ -9,8 +9,7 @@
 app_server <- function( input, output, session ) {
   # Your application server logic
   options(shiny.reactlog = TRUE)
-  
-  
+
   # AUTHENTICATION
   params <- parseQueryString(isolate(session$clientData$url_search))
   if (!has_auth_code(params)) {
@@ -35,10 +34,6 @@ app_server <- function( input, output, session ) {
   access_token <- token_response$access_token
   
   session$userData$access_token <- access_token
-  # DEV STUFF ###########################################################################
-  
-  # read in configs
-  global_config <- jsonlite::read_json("inst/global.json")
   
   # generate dashboard configuration from dataFlow schema
   dash_config <- dfamodules::generate_dashboard_config(schema_url = global_config$schema_url,
@@ -58,13 +53,13 @@ app_server <- function( input, output, session ) {
                                                                          release_scheduled = "Not Scheduled",
                                                                          embargo = "No Embargo",
                                                                          dataset = "No Manifest"),
-                                                       base_url = global_config$api_base_url)
+                                                       base_url = schematic_api_url)
   
   # download data flow status manifest
   manifest_obj <- dfamodules::dataset_manifest_download(asset_view = global_config$asset_view,
                                                         dataset_id = global_config$manifest_dataset_id,
                                                         access_token = access_token,
-                                                        base_url = global_config$api_base_url)
+                                                        base_url = schematic_api_url)
   
   manifest_dfa <- dfamodules::prep_manifest_dfa(manifest = manifest_obj$content,
                                                 config = dash_config)
@@ -246,7 +241,7 @@ app_server <- function( input, output, session ) {
   select_storage_project_out <- dfamodules::mod_select_storage_project_server(id = "select_storage_project_1",
                                                                               asset_view = global_config$asset_view,
                                                                               access_token = access_token,
-                                                                              base_url = global_config$api_base_url)
+                                                                              base_url = schematic_api_url)
   
   # DATASET SELECTION
   
@@ -254,7 +249,7 @@ app_server <- function( input, output, session ) {
                                                                 storage_project_df = select_storage_project_out,
                                                                 asset_view = global_config$asset_view,
                                                                 access_token = access_token,
-                                                                base_url = global_config$api_base_url)
+                                                                base_url = schematic_api_url)
   
   # UPDATE DATA FLOW STATUS SELECTIONS 
   updated_data_flow_status <- dfamodules::mod_update_data_flow_status_server("update_data_flow_status_1")
@@ -320,7 +315,7 @@ app_server <- function( input, output, session ) {
                                       dataset_id = global_config$manifest_dataset_id,
                                       manifest_dir = "./manifest",
                                       access_token = access_token,
-                                      base_url = global_config$api_base_url,
+                                      base_url = schematic_api_url,
                                       schema_url = global_config$schema_url)
   
 }

--- a/R/global.R
+++ b/R/global.R
@@ -1,4 +1,22 @@
-library(yaml)
+# READ IN CONFIG
+global_config <- jsonlite::read_json("inst/global.json")
+
+# GET SCHEMATIC API URL
+# If there is a config file, use that
+# Else use environment variables
+if ("schematic_api_url" %in% names(global_config)) {
+  schematic_api_url <- global_config$schematic_api_url
+} else {
+  schematic_api_url <- Sys.getenv("DFA_SCHEMATIC_API_URL")
+}
+
+# check that all variables are present
+if (is.null(schematic_api_url) || nchar(schematic_api_url) == 0) stop("missing DFA_SCHEMATIC_API_URL environmental variable")
+if (is.null(global_config$asset_view) || nchar(global_config$asset_view) == 0) stop("asset_view is missing from global.json")
+if (is.null(global_config$manifest_dataset_id) || nchar(global_config$manifest_dataset_id) == 0) stop("manifest_dataset_id is missing from global.json")
+if (is.null(global_config$schema_url) || nchar(global_config$schema_url) == 0) stop("schema_url is missing from global.json")
+
+message("DFA is using ", schematic_api_url)
 
 # SET UP OAUTH
 oauth_client <- yaml::yaml.load_file("oauth_config.yml")

--- a/R/global.R
+++ b/R/global.R
@@ -1,3 +1,5 @@
+Sys.getenv()
+
 # READ IN CONFIG
 global_config <- jsonlite::read_json("inst/global.json")
 

--- a/R/global.R
+++ b/R/global.R
@@ -1,4 +1,6 @@
-Sys.getenv()
+print(Sys.getenv())
+readRenviron(".Renviron")
+print(Sys.getenv())
 
 # READ IN CONFIG
 global_config <- jsonlite::read_json("inst/global.json")

--- a/inst/global.json
+++ b/inst/global.json
@@ -1,6 +1,5 @@
 {
     "asset_view": "syn50896957",
     "manifest_dataset_id": "syn50900267",
-    "schema_url": "https://raw.githubusercontent.com/Sage-Bionetworks/data_flow/main/inst/data_model/dataflow_component.jsonld",
-    "api_base_url": "https://schematic-dev.api.sagebionetworks.org"
+    "schema_url": "https://raw.githubusercontent.com/Sage-Bionetworks/data_flow/main/inst/data_model/dataflow_component.jsonld"
 }


### PR DESCRIPTION
Source the schematic API URL from the .Renviron. This allows for more flexibility on deployment.